### PR TITLE
[Fix] rename function _search by query.

### DIFF
--- a/vcd_cli/search.py
+++ b/vcd_cli/search.py
@@ -118,9 +118,9 @@ def search(ctx, resource_type, query_filter, fields, show_id, sort_asc, sort_des
         vcd search adminOrgVdc --fields 'name,orgName,providerVdcName' --hide-id --sort-asc name
           Search all vdc and show only some fields order y name.
     """
-    return _search(ctx, resource_type, query_filter, fields, show_id, sort_asc, sort_desc)
+    return query(ctx, resource_type, query_filter, fields, show_id, sort_asc, sort_desc)
 
-def _search(ctx, resource_type, query_filter, fields, show_id, sort_asc, sort_desc):
+def query(ctx, resource_type=None, query_filter=None, fields=None, show_id=True, sort_asc=None, sort_desc=None):
     try:
         if resource_type is None:
             click.secho(ctx.get_help())

--- a/vcd_cli/vm.py
+++ b/vcd_cli/vm.py
@@ -27,7 +27,7 @@ from vcd_cli.utils import restore_session
 from vcd_cli.utils import stderr
 from vcd_cli.utils import stdout
 from vcd_cli.vcd import vcd
-from vcd_cli.search import _search
+from vcd_cli.search import query
 
 
 @vcd.group(short_help='manage VMs')
@@ -366,10 +366,11 @@ def list_vms(ctx):
         filter = 'isVAppTemplate==false;vdc==%s' \
             % (vdc_href)
         fields='name,containerName,status'
+        sort_asc='containerName'
         resource=ResourceType.VM
         if client.is_sysadmin():
             resource=ResourceType.ADMIN_VM
-        _search(ctx, resource.value, query_filter=filter,fields=fields, show_id=False)
+        query(ctx, resource.value, query_filter=filter,fields=fields, show_id=False, sort_asc=sort_asc)
     except Exception as e:
         stderr(e, ctx)
 


### PR DESCRIPTION
Rename function _search by query because it's used in vm.py Extrat: Add sort by vapp name in 'vm list' that actually was using _search

Signed-off-by: Olivier DRAGHI <odraghi@gmail.com>